### PR TITLE
Updated tests to operate in temporary directories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,23 @@
-[build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
-
 [project]
 name = "eatlocal"
 authors = [{name = "Russell Helmstedter", email = "rhelmstedter@gmail.com"}]
 license = {file = "LICENSE"}
 classifiers = ["License :: OSI Approved :: MIT License"]
 dynamic = ["version", "description"]
-dependencies = ["selenium==4.1.0", "python-dotenv==0.19.2"]
+dependencies = ["selenium==4.1.0", "python-dotenv==0.19.2", "typer==0.4.0"]
 
 [project.urls]
 Home = "https://github.com/rhelmstedter/eatlocal"
+
+[tool.pytest.ini_options]
+markers = [
+        "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
+
+[build-system]
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
+
 
 [project.scripts]
 eatlocal = "eatlocal.__main__:main"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+"""eatlocal specific pytest configuration
+
+"""
+
+
+import os
+import shutil
+
+from pathlib import Path
+from typing import Union, Generator
+
+import pytest
+
+
+@pytest.fixture
+def bites_repo_dir(tmp_path) -> Generator[Path, None, None]:
+
+    cwd = Path.cwd()
+
+    os.chdir(tmp_path)
+
+    yield tmp_path
+
+    os.chdir(cwd)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,22 +1,71 @@
-import os
-import shutil
+""" eatlocal End to End Tests
+"""
+
+from pathlib import Path
+from typing import Tuple
+from zipfile import is_zipfile
 
 import pytest
 
 from eatlocal.constants import USERNAME, PASSWORD
-from eatlocal.eatlocal import download_bite
+from eatlocal.eatlocal import download_bite, extract_bite
+
+TEST_BITES = [1, 241, 306]
 
 
-def test_eatlocal_cannot_download_premium_bite_wo_auth(capfd):
-    bite_number = 241
-    download_bite(bite_number, "foo", "bar")
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "bite_number, creds",
+    [
+        (241, ("foo", "bar")),
+    ],
+)
+def test_eatlocal_cannot_download_premium_bite_wo_auth(
+    bite_number: int,
+    creds: Tuple[str, str],
+    capfd,
+) -> None:
+    """Attempt to download a bite ZIP archive file with incorrect credentials."""
+
+    download_bite(bite_number, *creds)
     output = capfd.readouterr()[0]
-    assert "Bite 241 was not downloaded" in output
+    assert "was not downloaded" in output
 
 
-@pytest.mark.parametrize("bite_number", [1, 241, 306])
-def test_eatlocal_downloads_correct_zipfile(bite_number):
+@pytest.mark.slow
+@pytest.mark.parametrize("bite_number", TEST_BITES)
+def test_eatlocal_downloads_correct_zipfile(
+    bite_number: int,
+    bites_repo_dir: Path,
+) -> None:
+    """Download a ZIP archive file for a specific bite with correct credentials.
+
+    Credentials are obtained either from the environment or the the .env
+    located in the directory pytest was launched in.
+
+    Checks for ZIP file existence before and after the download.
+    """
+    expected = Path(f"pybites_bite{bite_number}.zip")
+    assert not expected.exists()
     download_bite(bite_number, USERNAME, PASSWORD)
-    bite_dir = str(bite_number)
-    assert os.path.isdir(bite_dir)
-    shutil.rmtree(bite_dir)
+    assert expected.exists()
+    assert is_zipfile(expected)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("bite_number", TEST_BITES)
+def test_eatlocal_extract_download_zipfile(
+    bite_number: int,
+    bites_repo_dir: Path,
+) -> None:
+    """Download and extract a ZIP archive for a specific bite.
+
+    Checks for bite directory existence before and after the extraction.
+    """
+
+    expected = Path(str(bite_number))
+    download_bite(bite_number, USERNAME, PASSWORD)
+    assert not expected.exists()
+    extract_bite(bite_number)
+    assert expected.exists()
+    assert expected.is_dir()


### PR DESCRIPTION
I reworked all three of the end to end tests to use a `bites_repo_dir` fixture that creates a subdirectory in the test's base directory, changes to the directory while the tests are running and then returns the current working directory to what it was before the test started. The `bites_repo_dir` fixture has function scope.

I also added the `slow` mark to the end to end tests:

```python
@pytest.mark.slow
def test_something_slow(...):
    pass
```

Those tests can be selected via:

```console
$ pytest --markers
$ pytest -m slow            # only runs tests marked slow
$ pytest -m "not slow"      # runs all tests not marked slow
```

Added the marker definition to `pyproject.toml` in a stanza titled `[tool.pytest.ini-config]` as per the pytest documentation.