### PR TITLE
Feature: refactor command-line interface

### DIFF
--- a/eatlocal/eatlocal.py
+++ b/eatlocal/eatlocal.py
@@ -77,12 +77,12 @@ def download_bite(
         print(f"Bite {bite_number} was not downloaded")
 
 
-def extract_bite(bite_number: int, cleanup: bool = True) -> None:
+def extract_bite(bite_number: int, keep_zip: bool = False) -> None:
     """Extracts all the required files into a new directory
     named by the bite number.
 
     :bite_number: int The number of the bite you want to extract.
-    :cleanup: bool if True removes the downloaded zipfile
+    :keep_zip: bool if False removes the downloaded zipfile
     :returns: None
     """
 
@@ -92,7 +92,7 @@ def extract_bite(bite_number: int, cleanup: bool = True) -> None:
         with ZipFile(bite, "r") as zfile:
             zfile.extractall(f"./{bite_number}")
         print(f"Extracted bite {bite_number}")
-        if cleanup:
+        if not keep_zip:
             os.unlink(bite)
 
     except FileNotFoundError:


### PR DESCRIPTION
Download changed:
```
OLD $ eatlocal -d <bite>
NEW $ eatlocal download <bite>
```

Submit changed:
```
OLD $ eatlocal -s <bite>
NEW $ eatlocal submit <bite>
```

Removed the standalone extract command-line option.

Download operation now:
- downloads a bite zip archive into the current working directory
- extracts the archive into the current working directory
- optionally deletes the zip archive, default action is to delete

These changes required re-organizing the `__main__.py` functions, specifically breaking out all the option processing in the `main()` function into their own specific subcommands. 

The `global_options` function is a typer callback that is invoked before any of the other subcommand decorated functions, making it a good place to take care of global options that are used by the subcommands. In this particular case, it's the credentials for PyBites obtained from the environment. The credentials are passed to subcommands via the `typer.Context` automatic argument, specifically the `ctx.obj` attribute which can be any object. I created a `namedtuple` called `GlobalOptions` with a single member `creds` which is a tuple of username and password strings. 

While the user must type a little more, e.g. `download` vs `-d`, the code is much simplier and it will be easier to extend this utility when new functionality is identified. 