### PR TITLE
feature: download and extract now support a cache directory

### DIFF
--- a/eatlocal/__main__.py
+++ b/eatlocal/__main__.py
@@ -49,22 +49,22 @@ def global_options(
 def download_subcommand(
     ctx: typer.Context,
     bite_number: int,
-    keep_zip: bool = typer.Option(
+    cleanup: bool = typer.Option(
         False,
-        "--keep-zip",
-        "-k",
+        "--cleanup",
+        "-C",
         is_flag=True,
-        help="Keep the bite zip archive.",
+        help="Remove downloaded bite archive file.",
     ),
 ) -> None:
     """Download and extract bite code from Codechalleng.es.
 
     The bites are downloaded in a zip archive file and unzipped
-    in the current directory. If the `keep_zip` option is False
+    in the current directory. If the `cleanup` option is present
     the archive is deleted after extraction.
     """
-    download_bite(bite_number, *ctx.obj.creds)
-    extract_bite(bite_number, keep_zip=keep_zip)
+    download_bite(bite_number, *ctx.obj.creds, cache_path="cache")
+    extract_bite(bite_number, cleanup=cleanup, cache_path="cache")
 
 
 @cli.command(name="submit")

--- a/eatlocal/eatlocal.py
+++ b/eatlocal/eatlocal.py
@@ -1,32 +1,42 @@
+""" download and submit bites
+
+"""
+
+import subprocess
+import webbrowser
+
+from pathlib import Path
+from time import sleep
+from typing import ContextManager, Union
+from zipfile import ZipFile, is_zipfile
+
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 
-
-from time import sleep
-from zipfile import ZipFile
-
-import os
-import platform
-import subprocess
-import webbrowser
-
 from .constants import BITE_URL, BITE_ZIPFILE, LOGIN_URL, SUBMIT_URL
 
 
-def driver_setup() -> webdriver.Chrome:
-    """Sets up a headless Chrome wedriver and returns it.
+def driver_setup(path: Union[str, Path] = None) -> webdriver.Chrome:
+    """Configures a headless Chrome wedriver and returns it.
 
-    :returns: webdriver.Chrome
+    If a path is given, it's used to set the driver's default download
+    directory.
+
+    :path: Union[str, Path]
+    :returns: configured webdriver.Chrome
     """
+
+    path = str(Path(path or Path.cwd()).resolve())
+
     options = Options()
     options.add_argument("--headless")
     options.add_argument("window-size=1920x1080")
-    if platform.system() == "Windows":
-        chrome_prefs = {"download.default_directory": os.getcwd()}
-        options.experimental_options["prefs"] = chrome_prefs
+    chrome_prefs = {"download.default_directory": path}
+    options.experimental_options["prefs"] = chrome_prefs
+
     return webdriver.Chrome(options=options)
 
 
@@ -49,67 +59,122 @@ def pybites_login(driver: webdriver.Chrome, username: str, password: str) -> Non
     password_field.send_keys(Keys.RETURN)
 
 
+def find_cached_archive(bite_number: int, path: Union[str, Path] = None) -> Path:
+    """Return a Path for a PyBites bite zip archive in the given `path`.
+
+    :bite_number: int
+    :path: optional Path, resolved path defaults to current directory.
+    :return: Path
+
+    Raises:
+    - FileNotFoundError if archive not found in the target path.
+    """
+
+    path = Path(path or Path.cwd())
+
+    filename = BITE_ZIPFILE.format(bite_number=bite_number)
+
+    try:
+        archive = list(path.rglob(filename))[0]
+    except IndexError:
+        raise FileNotFoundError(filename) from None
+
+    return archive.resolve()
+
+
 def download_bite(
-    bite_number: int, username: str, password: str, delay: float = 1.5
+    bite_number: int,
+    username: str,
+    password: str,
+    delay: float = 1.5,
+    cache_path: Path = None,
 ) -> None:
-    """Download bite .zip from the platform.
+    """Download bite ZIP archive file from the platform to the current directory.
 
     :bite_number: int The number of the bite to download.
     :username: str
     :password: str
     :delay: float Time in seconds to pause between operations
+    :cache_path: Path for cached ZIP archive files, defaults to current directory
     :returns: None
     """
 
-    downloaded_bite = BITE_ZIPFILE.format(bite_number=bite_number)
-    driver = driver_setup()
-    pybites_login(driver, username, password)
+    try:
+        path = find_cached_archive(bite_number, path=cache_path)
+        print(f"Bite {bite_number} found: {path}")
+        return
+    except FileNotFoundError:
+        pass
 
-    print(f"Retrieving bite {bite_number}")
+    cache_path = Path(cache_path or Path.cwd()).resolve()
+    cache_path.mkdir(mode=0o755, parents=True, exist_ok=True)
+
+    print(f"Retrieving bite {bite_number}...")
     sleep(delay)
 
+    driver = driver_setup(cache_path)
+    pybites_login(driver, username, password)
     driver.get(BITE_URL.format(bite_number=bite_number))
     sleep(delay)
 
-    if os.path.exists(downloaded_bite):
-        print(f"Bite {bite_number} successully downloaded to current directory")
-    else:
-        print(f"Bite {bite_number} was not downloaded")
+    try:
+        bite_ziparchive = find_cached_archive(bite_number, path=cache_path)
+    except FileNotFoundError:
+        print(f"Bite {bite_number} was not downloaded.")
+        return
+
+    if not is_zipfile(bite_ziparchive):
+        print(f"Bite {bite_number} is not a valid archive file.")
+        return
+
+    print(f"Bite {bite_number} successully downloaded: {bite_ziparchive}")
 
 
-def extract_bite(bite_number: int, keep_zip: bool = False) -> None:
+def extract_bite(
+    bite_number: int,
+    dest_path: Path = None,
+    cleanup: bool = False,
+    cache_path: Path = None,
+) -> None:
     """Extracts all the required files into a new directory
     named by the bite number.
 
     :bite_number: int The number of the bite you want to extract.
-    :keep_zip: bool if False removes the downloaded zipfile
+    :cleanup: bool if False removes the downloaded zipfile.
+    :cache_path: Path to search for ZIp archive, defaults to current directory.
     :returns: None
     """
 
-    bite = BITE_ZIPFILE.format(bite_number=bite_number)
-
     try:
-        with ZipFile(bite, "r") as zfile:
-            zfile.extractall(f"./{bite_number}")
-        print(f"Extracted bite {bite_number}")
-        if not keep_zip:
-            os.unlink(bite)
+        bite = find_cached_archive(bite_number, path=cache_path)
+    except FileNotFoundError as error:
+        print(f"Missing ZIP archive for bite {bite_number}: {error}")
+        return
 
-    except FileNotFoundError:
-        print("No bite found.")
+    dest_path = Path(dest_path or Path.cwd()).resolve() / str(bite_number)
+
+    with ZipFile(bite, "r") as zipfile:
+        zipfile.extractall(dest_path)
+
+    print(f"Extracted bite {bite_number} @ {dest_path}")
+
+    if cleanup:
+        print(f"Cleaning up bite {bite_number} archive: {bite}")
+        bite.unlink()
 
 
 def submit_bite(
     bite_number: int, username: str, password: str, delay: float = 1.0
 ) -> None:
-    """Submits bite by pushing to git hub and opening
-    webbrowser to the bit page.
+    """Submits bite by pushing to GitHub and then opens a browser for the
+       bite page.
 
-    :bite_number: int The number of the bite you want to submit.
+    :bite_number: int The number of the bite to submit.
     :username: str
     :password: str
-    :delay: float Time in seconds to pause between operations
+    :delay: float time in seconds to pause between operations.
     :returns: None
+
     """
 
     try:


### PR DESCRIPTION
- Modified `eatlocal.eatlocal.driver_setup` to configure a download directory for all platforms, not just Windows.
- Added function `eatlocal.eatlocal.find_cached_archive` that returns the pathlib.Path for a bite archive file or raises **FileNotFoundError**.
- Updated docstrings.
    
Updated `eatlocal.eatlocal.download_bite`:
- added optional argument `cache_path`
- short circuits downloading bite archives if present in the cache
- saves the download archive file in the cache directory (. by default)
- enhanced error messages for different outcomes
    
Updated `eatlocal.eatlocal.extract_bite`:
- renamed `keep_zip` option to `cleanup`
- added optional argument `dest_path`
- added optional argument `cache_path`
- finds archive via function `find_cached_archive`
- archive extracted to `dest_path`, defaults to current working directory
- cached archive file is removed if `cleanup` is True
- enhanced user messages